### PR TITLE
stop SSL verification (which started by default for python v2.7.9+)

### DIFF
--- a/health_check
+++ b/health_check
@@ -91,13 +91,19 @@ import re
 import socket
 import time
 import urllib2
+import ssl
 
 
 def check_server_status(url, headers, timeout, expected_status,
                         expected_regexp):
+    
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    
     request = urllib2.Request(url, headers=headers)
     try:
-        fp = urllib2.urlopen(request, timeout=timeout)
+        fp = urllib2.urlopen(request, timeout=timeout, context=context)
     except (urllib2.URLError, httplib.HTTPException, socket.error), e:
         return False, str(e)
 


### PR DESCRIPTION
urllib2 verifies server certificate by default on python >= 2.7.9
Which may produce inconsistent results, or fail.
This is a bit dirty and not flag option (yet) but will enable simple health_check to work as intended.